### PR TITLE
오브젝트 캐시를 사용하여 성능 개선

### DIFF
--- a/attendance.admin.controller.php
+++ b/attendance.admin.controller.php
@@ -176,6 +176,9 @@ class attendanceAdminController extends attendance
 			$oPointController->setPoint($member_srl,$personal_point,'update');
 			if($action=='update') $this->setMessage('attend_updated_points');
 		}
+
+		// 캐시 비우기
+		$oAttendanceModel->clearCacheByMemberSrl($member_srl);
 	}
 
 
@@ -215,6 +218,9 @@ class attendanceAdminController extends attendance
 		$oAttendanceModel->insertTotal($obj->member_srl, $continuity, $attendance, $sum, $obj->selected_date.'000000');
 
 		$oAttendanceAdminModel->fixYearMonthWeek($obj);
+
+		// 캐시 비우기
+		$oAttendanceModel->clearCacheByMemberSrl($obj->member_srl);
 	}
 
 	/**
@@ -286,6 +292,9 @@ class attendanceAdminController extends attendance
 		$args->today_point = $today_point;
 		executeQuery('attendance.insertAttendance', $args);
 		$this->setMessage('attend_fixed_doublecheck');
+
+		// 캐시 비우기
+		$oAttendanceModel->clearCacheByMemberSrl($obj->member_srl);
 	}
 
 	/**
@@ -334,6 +343,9 @@ class attendanceAdminController extends attendance
 
 			$oAttendanceAdminModel->fixYearMonthWeek($obj);
 		}
+
+		// 캐시 비우기
+		$oAttendanceModel->clearCache();
 	}
 
 	/**
@@ -400,6 +412,9 @@ class attendanceAdminController extends attendance
 		$oModuleController = getController('module');
 		$module_info = $oModuleModel->getModuleInfoByMid('attendance');
 		$oModuleController->deleteModule($module_info->module_srl);
+
+		// 캐시 비우기
+		$oAttendanceModel->clearCache();
 	}
 
 	function procAttendanceAdminInsertGift()

--- a/attendance.admin.controller.php
+++ b/attendance.admin.controller.php
@@ -83,6 +83,7 @@ class attendanceAdminController extends attendance
 		$config->giftname = $obj->giftname;
 		$config->manygiftlist = $obj->manygiftlist;
 		$config->gift_random = $obj->gift_random;
+		$config->use_cache = $obj->attendance_use_cache === 'yes' ? 'yes' : 'no';
 		$config->greeting_list = $obj->greeting_list;
 
 		if(date('t', mktime(0,0,0,02,1,zDate(date('YmdHis'),"Y")))==29)

--- a/attendance.admin.model.php
+++ b/attendance.admin.model.php
@@ -209,11 +209,18 @@ class attendanceAdminModel extends attendance
 	/**
 	 * @brief 오늘 총 출석인원 계산
 	 **/
-	function getTodayTotalCount($today){
+	function getTodayTotalCount($today)
+	{
+		static $cache = array();
+		if(isset($cache[$today]))
+		{
+			return $cache[$today];
+		}
+		
 		$arg = new stdClass();
 		$arg->today = $today;
 		$output = executeQuery("attendance.getTodayTotalCount",$arg);
-		return (int)$output->data->count;
+		return $cache[$today] = (int)$output->data->count;
 	}
 
 	/**
@@ -221,10 +228,16 @@ class attendanceAdminModel extends attendance
 	 **/
 	function getTodayTimeCount($today_time)
 	{
+		static $cache = array();
+		if(isset($cache[$today_time]))
+		{
+			return $cache[$today_time];
+		}
+		
 		$arg = new stdClass();
 		$arg->today_time = $today_time;
 		$output = executeQuery("attendance.getTodayTimeCount",$arg);
-		return (int)$output->data->count;
+		return $cache[$today_time] = (int)$output->data->count;
 	}
 
 	/**

--- a/attendance.admin.model.php
+++ b/attendance.admin.model.php
@@ -254,6 +254,8 @@ class attendanceAdminModel extends attendance
 		$args = new stdClass();
 		$args->member_srl = $member_srl;
 		$output = executeQuery("attendance.deleteAllAttendanceData",$args);
+
+		$oAttendanceModel->clearCacheByMemberSrl($member_srl);
 	}
 
 	/**
@@ -264,6 +266,9 @@ class attendanceAdminModel extends attendance
 		$args = new stdClass();
 		$args->member_srl = $member_srl;
 		$output = executeQuery("attendance.deleteAllAttendanceTotalData",$args);
+
+		$oAttendanceModel = getModel('attendance');
+		$oAttendanceModel->clearCacheByMemberSrl($member_srl);
 	}
 
 	/**
@@ -274,6 +279,9 @@ class attendanceAdminModel extends attendance
 		$args = new stdClass();
 		$args->member_srl = $member_srl;
 		$output = executeQuery("attendance.deleteAllAttendanceYearlyData",$args);
+
+		$oAttendanceModel = getModel('attendance');
+		$oAttendanceModel->clearCacheByMemberSrl($member_srl);
 	}
 
 	/**
@@ -284,6 +292,9 @@ class attendanceAdminModel extends attendance
 		$args = new stdClass();
 		$args->member_srl = $member_srl;
 		$output = executeQuery("attendance.deleteAllAttendanceMonthlyData",$args);
+
+		$oAttendanceModel = getModel('attendance');
+		$oAttendanceModel->clearCacheByMemberSrl($member_srl);
 	}
 
 	/**
@@ -294,6 +305,9 @@ class attendanceAdminModel extends attendance
 		$args = new stdClass();
 		$args->member_srl = $member_srl;
 		$output = executeQuery("attendance.deleteAllAttendanceWeeklyData",$args);
+
+		$oAttendanceModel = getModel('attendance');
+		$oAttendanceModel->clearCacheByMemberSrl($member_srl);
 	}
 
 	/**
@@ -306,6 +320,9 @@ class attendanceAdminModel extends attendance
 		$args->sunday = $week->sunday;
 		$args->member_srl = $member_srl;
 		$output = executeQuery("attendance.deleteAttendanceWeeklyData",$args);
+
+		$oAttendanceModel = getModel('attendance');
+		$oAttendanceModel->clearCacheByMemberSrl($member_srl, 'weekly', $week);
 	}
 
 	/**
@@ -317,6 +334,9 @@ class attendanceAdminModel extends attendance
 		$args->monthly = $monthly;
 		$args->member_srl = $member_srl;
 		$output = executeQuery("attendance.deleteAttendanceMonthlyData",$args);
+
+		$oAttendanceModel = getModel('attendance');
+		$oAttendanceModel->clearCacheByMemberSrl($member_srl, 'monthly', $monthly);
 	}
 
 	/**
@@ -328,6 +348,9 @@ class attendanceAdminModel extends attendance
 		$args->year = $year;
 		$args->member_srl = $member_srl;
 		$output = executeQuery("attendance.deleteAttendanceYearlyData",$args);
+
+		$oAttendanceModel = getModel('attendance');
+		$oAttendanceModel->clearCacheByMemberSrl($member_srl, 'yearly', $yearly);
 	}
 
 	/**
@@ -447,5 +470,7 @@ class attendanceAdminModel extends attendance
 		}
 		$attendance = $oAttendanceModel->getWeeklyAttendance($obj->member_srl, $week);
 		$oAttendanceModel->insertWeekly($obj->member_srl, $attendance, $sum, $obj->selected_date.'000000');
+		
+		$oAttendanceModel->clearCacheByMemberSrl($obj->member_srl);
 	}
 }

--- a/attendance.admin.view.php
+++ b/attendance.admin.view.php
@@ -143,6 +143,7 @@ class attendanceAdminView extends attendance
 
 		Context::set('module_info',$module_info);
 		Context::set('module_srl', $module_info->module_srl);
+		Context::set('object_cache_available', preg_match('/^(apc|file|memcache|redis|wincache|xcache|sqlite)/', Context::getDbInfo()->use_object_cache));
 
 		// 사용환경정보 전송 확인
 		$attendance_module_info = $oModuleModel->getModuleInfoXml('attendance');

--- a/attendance.controller.php
+++ b/attendance.controller.php
@@ -44,6 +44,10 @@ class attendanceController extends attendance
 		{
 			$this->errorMessage('에러발생');
 		}
+		
+		$oAttendanceModel = getModel('attendance');
+		$oAttendanceModel->clearCacheByMemberSrl($member_srl);
+		
 		if(!in_array(Context::getRequestMethod(),array('XMLRPC','JSON')))
 		{
 			$returnUrl = Context::get('success_return_url') ? Context::get('success_return_url') : getNotEncodedUrl('', 'mid', 'attendance', 'act', 'dispAttendanceModifyContinuous', 'member_srl', $member_srl);
@@ -570,6 +574,8 @@ class attendanceController extends attendance
 			$oAttendanceModel->updateWeekly($member_info->member_srl, $week, $weekly_data, $weekly_point, null);
 		}
 
+		/* 캐시 비우기 */
+		$oAttendanceModel->clearCacheByMemberSrl($member_info->member_srl);
 	}
 
 	/**
@@ -714,6 +720,12 @@ class attendanceController extends attendance
 			}
 			$this->setMessage("success_deleted");
 		}
+		
+		/* 캐시 비우기 */
+		$oAttendanceModel->clearCacheByMemberSrl($obj->member_srl, 'daily', $obj->check_day);
+		$oAttendanceModel->clearCacheByMemberSrl($obj->member_srl, 'weekly', $week);
+		$oAttendanceModel->clearCacheByMemberSrl($obj->member_srl, 'monthly', $year_month);
+		$oAttendanceModel->clearCacheByMemberSrl($obj->member_srl, 'yearly', $year);
 	}
 
 	/**
@@ -780,6 +792,9 @@ class attendanceController extends attendance
 		$oAttendanceModel->updateAttendance($obj->attendance_srl, $regdate, $obj->today_point, null, null);
 
 		//회원의 출석통계 갱신
+		
+		/* 캐시 비우기 */
+		$oAttendanceModel->clearCacheByMemberSrl($oAttendance->member_srl);
 	}
 
     /**
@@ -794,6 +809,8 @@ class attendanceController extends attendance
 		$oAttendanceAdminModel->deleteAllAttendanceYearlyData($obj->member_srl);
 		$oAttendanceAdminModel->deleteAllAttendanceMonthlyData($obj->member_srl);
 		$oAttendanceAdminModel->deleteAllAttendanceWeeklyData($obj->member_srl);
+		$oAttendanceModel = getModel('attendance');
+		$oAttendanceModel->clearCacheByMemberSrl($obj->member_srl);
 		return new Object();
 	}
     

--- a/attendance.model.php
+++ b/attendance.model.php
@@ -879,6 +879,7 @@ class attendanceModel extends attendance
 		$monthly = ($type === 'monthly' && $condition) ? $condition : zDate(date('YmdHis'), "Ym");
 		$yearly = ($type === 'yearly' && $condition) ? $condition : zDate(date('YmdHis'), "Y");
 		
+		$oCacheHandler->delete($oCacheHandler->getGroupKey('attendance', "todaytotal:$daily"));
 		$oCacheHandler->delete($oCacheHandler->getGroupKey('attendance', "member:$member_srl:daily:$daily"));
 		$oCacheHandler->delete($oCacheHandler->getGroupKey('attendance', "member:$member_srl:weekly:$weekly"));
 		$oCacheHandler->delete($oCacheHandler->getGroupKey('attendance', "member:$member_srl:monthly:$monthly"));
@@ -887,7 +888,7 @@ class attendanceModel extends attendance
 		$oCacheHandler->delete($oCacheHandler->getGroupKey('attendance', "member:$member_srl:totalpoint"));
 		$oCacheHandler->delete($oCacheHandler->getGroupKey('attendance', "member:$member_srl:totaldata"));
 	}
-	
+
 	/**
 	 * @brief 모든 회원의 출석 통계 캐시 삭제
 	 */

--- a/attendance.model.php
+++ b/attendance.model.php
@@ -38,6 +38,7 @@ class attendanceModel extends attendance
 			if(!$config->about_diligence_yearly) $config->about_diligence_yearly = 'no';
 			if(!$config->allow_duplicaton_ip_count) $config->allow_duplicaton_ip_count = '3';
 			if(!$config->about_admin_check) $config->about_admin_check = 'yes';
+			if(!$config->use_cache) $config->use_cache = 'yes';
 
 			self::$config = $config;
 		}
@@ -911,10 +912,17 @@ class attendanceModel extends attendance
 		static $oCacheHandler = null;
 		if($oCacheHandler === null)
 		{
-			$oCacheHandler = CacheHandler::getInstance('object');
-			if(!$oCacheHandler->isSupport())
+			if($this->getConfig()->use_cache !== 'yes')
 			{
 				$oCacheHandler = false;
+			}
+			else
+			{
+				$oCacheHandler = CacheHandler::getInstance('object');
+				if(!$oCacheHandler->isSupport())
+				{
+					$oCacheHandler = false;
+				}
 			}
 		}
 		return $oCacheHandler;

--- a/attendance.model.php
+++ b/attendance.model.php
@@ -190,11 +190,25 @@ class attendanceModel extends attendance
 	 */
 	function getMonthlyData($monthly, $member_srl)
 	{
+		if($oCacheHandler = $this->getCacheHandler())
+		{
+			if(($result = $oCacheHandler->get($oCacheHandler->getGroupKey('attendance', "member:$member_srl:monthly:$monthly"), time() - 86400)) !== false)
+			{
+				return $result;
+			}
+		}
+		
 		$args = new stdClass();
 		$args->monthly = $monthly;
 		$args->member_srl = $member_srl;
 		$output = executeQuery('attendance.getMonthlyData', $args);
-		return (int)$output->data->monthly_count;
+		$result = (int)$output->data->monthly_count;
+		
+		if($oCacheHandler)
+		{
+			$oCacheHandler->put($oCacheHandler->getGroupKey('attendance', "member:$member_srl:monthly:$monthly"), $result, 86400);
+		}
+		return $result;
 	}
 
 	/**
@@ -202,11 +216,25 @@ class attendanceModel extends attendance
 	 */
 	function getYearlyData($yearly, $member_srl)
 	{
+		if($oCacheHandler = $this->getCacheHandler())
+		{
+			if(($result = $oCacheHandler->get($oCacheHandler->getGroupKey('attendance', "member:$member_srl:yearly:$yearly"), time() - 86400)) !== false)
+			{
+				return $result;
+			}
+		}
+		
 		$args = new stdClass();
 		$args->yearly = $yearly;
 		$args->member_srl=$member_srl;
 		$output = executeQuery('attendance.getYearlyData', $args);
-		return (int)$output->data->yearly_count;
+		$result = (int)$output->data->yearly_count;
+		
+		if($oCacheHandler)
+		{
+			$oCacheHandler->put($oCacheHandler->getGroupKey('attendance', "member:$member_srl:yearly:$yearly"), $result, 86400);
+		}
+		return $result;
 	}
 
 	/**
@@ -214,11 +242,7 @@ class attendanceModel extends attendance
 	 */
 	function getIsChecked($member_srl)
 	{
-		$arg = new stdClass();
-		$arg->day = zDate(date('YmdHis'),"Ymd");
-		$arg->member_srl = $member_srl;
-		$output = executeQuery('attendance.getIsChecked',$arg);
-		return (int)$output->data->count;
+		return $this->getIsCheckedA($member_srl, zDate(date('YmdHis'),"Ymd"));
 	}
 
 	/**
@@ -226,11 +250,25 @@ class attendanceModel extends attendance
 	 */
 	function getIsCheckedA($member_srl, $today)
 	{
+		if($oCacheHandler = $this->getCacheHandler())
+		{
+			if(($result = $oCacheHandler->get($oCacheHandler->getGroupKey('attendance', "member:$member_srl:daily:$today"), time() - 86400)) !== false)
+			{
+				return $result;
+			}
+		}
+		
 		$arg = new stdClass();
 		$arg->day = $today;
 		$arg->member_srl = $member_srl;
 		$output = executeQuery('attendance.getIsChecked',$arg);
-		return (int)$output->data->count;
+		$result = (int)$output->data->count;
+		
+		if($oCacheHandler)
+		{
+			$oCacheHandler->put($oCacheHandler->getGroupKey('attendance', "member:$member_srl:daily:$today"), $result, 86400);
+		}
+		return $result;
 	}
 
     /**
@@ -409,10 +447,24 @@ class attendanceModel extends attendance
 	 */
 	function getTotalAttendance($member_srl)
 	{
+		if($oCacheHandler = $this->getCacheHandler())
+		{
+			if(($result = $oCacheHandler->get($oCacheHandler->getGroupKey('attendance', "member:$member_srl:totalcount"), time() - 86400)) !== false)
+			{
+				return $result;
+			}
+		}
+		
 		$args = new stdClass();
 		$args->member_srl=$member_srl;
 		$output = executeQuery('attendance.getTotalAttendance', $args);
-		return (int)$output->data->total_count;
+		$result = (int)$output->data->total_count;
+		
+		if($oCacheHandler)
+		{
+			$oCacheHandler->put($oCacheHandler->getGroupKey('attendance', "member:$member_srl:totalcount"), $result, 86400);
+		}
+		return $result;
 	}
 
 	/**
@@ -420,10 +472,24 @@ class attendanceModel extends attendance
 	 */
 	function getTotalPoint($member_srl)
 	{
+		if($oCacheHandler = $this->getCacheHandler())
+		{
+			if(($result = $oCacheHandler->get($oCacheHandler->getGroupKey('attendance', "member:$member_srl:totalpoint"), time() - 86400)) !== false)
+			{
+				return $result;
+			}
+		}
+		
 		$args = new stdClass();
 		$args->member_srl = $member_srl;
 		$output = executeQuery('attendance.getTotalPoint', $args);
-		return (int)$output->data->total_point;
+		$result = (int)$output->data->total_point;
+		
+		if($oCacheHandler)
+		{
+			$oCacheHandler->put($oCacheHandler->getGroupKey('attendance', "member:$member_srl:totalpoint"), $result, 86400);
+		}
+		return $result;
 	}
 
 
@@ -432,6 +498,14 @@ class attendanceModel extends attendance
 	 */
 	function getTotalData($member_srl)
 	{
+		if($oCacheHandler = $this->getCacheHandler())
+		{
+			if(($total_info = $oCacheHandler->get($oCacheHandler->getGroupKey('attendance', "member:$member_srl:totaldata"), time() - 86400)) !== false)
+			{
+				return $total_info;
+			}
+		}
+		
 		$arg = new stdClass();
 		$arg->member_srl = $member_srl;
 		$output = executeQuery('attendance.getTotalData',$arg);
@@ -441,6 +515,11 @@ class attendanceModel extends attendance
 		$total_info->continuity_point = (int)$output->data->continuity_point;
 		$total_info->continuity = (int)$output->data->continuity;
 		$total_info->regdate = $output->data->regdate;
+		
+		if($oCacheHandler)
+		{
+			$oCacheHandler->put($oCacheHandler->getGroupKey('attendance', "member:$member_srl:totaldata"), $total_info, 86400);
+		}
 		return $total_info;
 	}
 
@@ -640,6 +719,15 @@ class attendanceModel extends attendance
 	 */
 	function getWeeklyData($member_srl, $week)
 	{
+		$week_cache_key = $week->sunday;
+		if($oCacheHandler = $this->getCacheHandler())
+		{
+			if(($week_data = $oCacheHandler->get($oCacheHandler->getGroupKey('attendance', "member:$member_srl:weekly:$week_cache_key"), time() - 86400)) !== false)
+			{
+				return $week_data;
+			}
+		}
+		
 		$arg = new stdClass();
 		$arg->member_srl = $member_srl;
 		$arg->sunday = $week->sunday;
@@ -648,6 +736,11 @@ class attendanceModel extends attendance
 		$week_data = new stdClass();
 		$week_data->weekly = (int)$output->data->weekly;
 		$week_data->weekly_point = (int)$output->data->weekly_point;
+		
+		if($oCacheHandler)
+		{
+			$oCacheHandler->put($oCacheHandler->getGroupKey('attendance', "member:$member_srl:weekly:$week_cache_key"), $week_data, 86400);
+		}
 		return $week_data;
 	}
 
@@ -757,5 +850,72 @@ class attendanceModel extends attendance
 		$output = executeQueryArray('attendance.getGreetingsList',$arg);
 		if(!$output->data) $output->data = array();
 		return $output;
+	}
+
+
+	/*******************************************************
+	*                    캐싱 관련 함수                    *
+	********************************************************/
+	
+	/**
+	 * @brief 주어진 회원의 출석 통계 캐시 삭제
+	 */
+	function clearCacheByMemberSrl($member_srl, $type = 'all', $condition = null)
+	{
+		$member_srl = (int)$member_srl;
+		if(!$member_srl)
+		{
+			return;
+		}
+		
+		$oCacheHandler = $this->getCacheHandler();
+		if(!$oCacheHandler)
+		{
+			return;
+		}
+		
+		$daily = ($type === 'daily' && $condition) ? $condition : zDate(date('YmdHis'), "Ymd");
+		$weekly = ($type === 'weekly' && $condition) ? $condition->sunday : $this->getWeek(date('YmdHis'))->sunday;
+		$monthly = ($type === 'monthly' && $condition) ? $condition : zDate(date('YmdHis'), "Ym");
+		$yearly = ($type === 'yearly' && $condition) ? $condition : zDate(date('YmdHis'), "Y");
+		
+		$oCacheHandler->delete($oCacheHandler->getGroupKey('attendance', "member:$member_srl:daily:$daily"));
+		$oCacheHandler->delete($oCacheHandler->getGroupKey('attendance', "member:$member_srl:weekly:$weekly"));
+		$oCacheHandler->delete($oCacheHandler->getGroupKey('attendance', "member:$member_srl:monthly:$monthly"));
+		$oCacheHandler->delete($oCacheHandler->getGroupKey('attendance', "member:$member_srl:yearly:$yearly"));
+		$oCacheHandler->delete($oCacheHandler->getGroupKey('attendance', "member:$member_srl:totalcount"));
+		$oCacheHandler->delete($oCacheHandler->getGroupKey('attendance', "member:$member_srl:totalpoint"));
+		$oCacheHandler->delete($oCacheHandler->getGroupKey('attendance', "member:$member_srl:totaldata"));
+	}
+	
+	/**
+	 * @brief 모든 회원의 출석 통계 캐시 삭제
+	 */
+	function clearCache()
+	{
+		$oCacheHandler = $this->getCacheHandler();
+		if(!$oCacheHandler)
+		{
+			return;
+		}
+		
+		$oCacheHandler->invalidateGroupKey('attendance');
+	}
+	
+	/**
+	 * @brief 캐시 핸들러를 사용할 수 있는지 확인하고, 사용할 수 있다면 인스턴스를 반환
+	 */
+	function getCacheHandler()
+	{
+		static $oCacheHandler = null;
+		if($oCacheHandler === null)
+		{
+			$oCacheHandler = CacheHandler::getInstance('object');
+			if(!$oCacheHandler->isSupport())
+			{
+				$oCacheHandler = false;
+			}
+		}
+		return $oCacheHandler;
 	}
 }

--- a/lang/lang.xml
+++ b/lang/lang.xml
@@ -563,6 +563,12 @@
 	<item name="birthday_member_help">
 		<value xml:lang="ko"><![CDATA[회원정보에서 생일을 수정 할 수 있도록 개선 해줍니다.]]></value>
 	</item>
+	<item name="attendance_use_cache">
+		<value xml:lang="ko"><![CDATA[오브젝트 캐시 사용]]></value>
+	</item>
+	<item name="attendance_use_cache_help">
+		<value xml:lang="ko"><![CDATA[XE의 오브젝트 캐시를 활용하여 출석부 성능을 향상시킵니다.]]></value>
+	</item>
 	<item name="use_document">
 		<value xml:lang="ko"><![CDATA[문서모듈 설정]]></value>
 	</item>

--- a/m.skins/default/index.html
+++ b/m.skins/default/index.html
@@ -152,9 +152,8 @@
         {@$is_perfect=$oAttendanceModel->isPerfect($data->member_srl, $selected_date)}
         {@$weekly = $oAttendanceModel->getWeeklyData($data->member_srl, $week)}
             {@$member = $oMemberModel->getMemberInfoByMemberSrl($data->member_srl)}
-            <!--@if(preg_match("/^#[0-9]+$/",$data->greetings))-->
-                {@$length_greetings = strlen($data->greetings) -1}
-                {@$oDocument = $oDocumentModel->getDocument(substr($data->greetings,1,$length_greetings))}
+            <!--@if(preg_match("/^#([0-9]+)$/",$data->greetings, $document_srl))-->
+                {@$oDocument = $oDocumentModel->getDocument($document_srl[1], false, false)}
                 <!--@if($oDocument->document_srl)-->
                     {@$exist_document = 1}
                 <!--@else-->

--- a/skins/default/board.html
+++ b/skins/default/board.html
@@ -34,9 +34,8 @@
 		{@ $weekly = $oAttendanceModel->getWeeklyData($data->member_srl, $week)}
 		{@ $member = $oMemberModel->getMemberInfoByMemberSrl($data->member_srl)}
 
-			<!--@if(preg_match("/^#[0-9]+$/",$data->greetings))-->
-				{@$length_greetings = strlen($data->greetings) -1}
-				{@$oDocument = $oDocumentModel->getDocument(substr($data->greetings,1,$length_greetings))}
+			<!--@if(preg_match("/^#([0-9]+)$/",$data->greetings, $document_srl))-->
+				{@$oDocument = $oDocumentModel->getDocument($document_srl[1], false, false)}
 				<!--@if($oDocument->document_srl)-->
 					{@$exist_document = 1}
 				<!--@else-->

--- a/skins/default/twitter_board.html
+++ b/skins/default/twitter_board.html
@@ -33,9 +33,8 @@
 	<li class="lulu-item cfix" loop="$oAttendance->data=>$data">
 
 			
-			<!--@if(preg_match("/^#[0-9]+$/",$data->greetings))-->
-				{@$length_greetings = strlen($data->greetings) -1}
-				{@$oDocument = $oDocumentModel->getDocument(substr($data->greetings,1,$length_greetings))}
+			<!--@if(preg_match("/^#([0-9]+)$/",$data->greetings, $document_srl))-->
+				{@$oDocument = $oDocumentModel->getDocument($document_srl[1], false, false)}
 				<!--@if($oDocument->document_srl)-->
 					{@$exist_document = 1}
 				<!--@else-->

--- a/tpl/config.html
+++ b/tpl/config.html
@@ -373,6 +373,16 @@
 			</div>
 		</div>
 		<div class="x_control-group">
+			<label class="x_control-label">{$lang->attendance_use_cache}</label>
+			<div class="x_controls">
+				<select name="attendance_use_cache" disabled="disabled"|cond="!$object_cache_available">
+					<option value="yes" selected="selected"|cond="$config->use_cache=='yes' && $object_cache_available">{$lang->attendance_yes}</option>
+					<option value="no" selected="selected"|cond="$config->use_cache=='no' || !$object_cache_available">{$lang->attendance_no}</option>
+				</select>
+				<p>{$lang->attendance_use_cache_help}</p>
+			</div>
+		</div>
+		<div class="x_control-group">
 			<label class="x_control-label">인사말 설정</label>
 			<div class="x_controls">
 				<textarea name="greeting_list" style="width:300px; height:200px;">{htmlspecialchars($config->greeting_list)}</textarea>


### PR DESCRIPTION
XE에서 오브젝트 캐시를 사용하는 경우 이것을 활용하여 출석부 성능을 개선합니다. 기본 스킨 및 서드파티 스킨에서 자주 호출하는 함수들을 위주로 최적화하였습니다.

- getTodayTotalCount
- getTodayTimeCount
- getIsChecked
- getIsCheckedA
- getYearlyData
- getMonthlyData
- getWeeklyData
- getTotalData
- getTotalAttendance
- getTotalPoint

스킨이나 이용패턴에 따라 무려 80~160개의 쿼리를 절약할 수 있습니다. 회원 수가 많고 다년간의 데이터가 축적되어 있는 사이트에서 출석부 로딩 속도가 획기적으로 빨라집니다.

관리자가 특정 회원의 출석 내역을 삭제하거나 수정하는 경우 캐시를 갱신하도록 하였으나, 정확하게 갱신되지 않을 수도 있으므로 확인이 필요합니다.