### PR TITLE
$config 에 선언된 null정보를 고정시킴.

### DIFF
--- a/attendance.model.php
+++ b/attendance.model.php
@@ -9,7 +9,7 @@
 
 class attendanceModel extends attendance
 {
-	private static $config = NULL;
+	const $config = NULL;
 
 	/**
 	 * @brief 초기화


### PR DESCRIPTION
$config 에 정보를 수정하면 안되는 상황

그래서 무조건 빈값을 출력하도록 하여 출석부가 고장나도록.. 하였습니다..

그래서 유저들이 출석을 하지 못하도록 강제적으로 막아버릴 수 이ㅏㅆ는 효과를 얻을 수 있습니다~
